### PR TITLE
Remove link to uncontrolled domain in install instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ layout: default
 						<i class="fa fa-square fa-stack-2x"></i>
 						<i class="fa fa-terminal fa-stack-1x fa-inverse"></i>
 					</span>
-					<code>curl -sL zplug.sh/installer | zsh</code>
+					<code>curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh | zsh</code>
 				</p>
 				<a href="#" class="btn btn-dark">View More</a>
 				</div>


### PR DESCRIPTION
Per https://github.com/zplug/zplug/issues/403 this domain is no longer under the zplug project's maintainer's control - we should not be encouraging people to execute some random script.